### PR TITLE
make scoop.logger output go to stderr by default

### DIFF
--- a/scoop/utils.py
+++ b/scoop/utils.py
@@ -69,7 +69,7 @@ def initLogging(verbosity=0, name="SCOOP"):
             {
                 "class": "logging.StreamHandler",
                 "formatter": "{name}Formatter".format(name=name),
-                "stream": "ext://sys.stdout",
+                "stream": "ext://sys.stderr",
             },
         }
         loggingConfig.update({


### PR DESCRIPTION
by default the logging module logs to stderr, keeping stdout free for normal program output.