### PR TITLE
unicode exceptions no longer crash workers, fixes #23

### DIFF
--- a/scoop/_control.py
+++ b/scoop/_control.py
@@ -152,10 +152,9 @@ def runFuture(future):
         future.exceptionValue = err
         future.exceptionTraceback = str(traceback.format_exc())
         scoop.logger.debug(
-            "The following error occured on a worker:\n{err}\n{tb}".format(
-                err=err,
-                tb=traceback.format_exc(),
-            )
+            "The following error occured on a worker:\n%r\n%s",
+            err,
+            traceback.format_exc(),
         )
     future.executionTime = future.stopWatch.get()
     future.isDone = True


### PR DESCRIPTION
This changes the debug logging to log the `repr` of the exception. Also it uses the logging embedded format feature which only does any of the formatting if the exception is actually logged.

I didn't know how to run your tests, but i'd suggest to include the code from #23 as a test.