### PR TITLE
Fixed "Error with SLURM #26"

### DIFF
--- a/scoop/utils.py
+++ b/scoop/utils.py
@@ -207,14 +207,19 @@ def parseSLURM(string):
 
     hosts = []
 
-    # parse out the name followed by range (ex. borgb[001-002,004-006]
+    # parse out the name followed by range (ex. borgb[001-002,004-006,008]
     for h,n in bunchedlist:
 
         block = re.findall('([^\[\],]+)', n)
         for rng in block:
-
-            bmin, bmax = rng.split('-')
-            fill_width = max(len(bmin), len(bmax))
+            
+            if '-' in rng:
+                bmin,bmax = rng.split('-')
+                fill_width = max(len(bmin),len(bmax))
+            else:
+                bmin = rng
+                bmax = bmin
+                fill_width = len(bmin)
             for i in range(int(bmin), int(bmax) + 1):
                 hostname = str(h) + str(i).zfill(fill_width)
                 hosts.append((hostname, int(1)))

--- a/scoop/utils.py
+++ b/scoop/utils.py
@@ -207,6 +207,11 @@ def parseSLURM(string):
 
     hosts = []
 
+    # for the single node case
+    if len(bunchedlist) == 0:
+        hosts.append((string, int(1)))
+        return hosts
+    
     # parse out the name followed by range (ex. borgb[001-002,004-006,008]
     for h,n in bunchedlist:
 

--- a/test/tests_parser.py
+++ b/test/tests_parser.py
@@ -92,6 +92,18 @@ class TestUtils(unittest.TestCase):
                 result.append(("{prefix}{num}".format(**locals()), 1))
         self.assertEqual(set(hosts), set(result))
 
+    def test_parseSLURM_nondashOneDecimal(self):
+        hosts = utils.parseSLURM("n[1,4]")
+        result = []
+        result = zip(("n{0}".format(x) for x in [1, 4]), repeat(1))
+        self.assertEqual(set(hosts), set(result))
+
+    def test_parseSLURM_nondash_and_dashOneDecimal(self):
+        hosts = utils.parseSLURM("n[1,5-9]")
+        result = []
+        result = zip(("n{0}".format(x) for x in [1, 5, 6, 7, 8, 9]), repeat(1))
+        self.assertEqual(set(hosts), set(result))
+        
     def test_getHostsFile(self):
         self.assertEqual(set(utils.getHosts("hostfilesim.txt")), set(hosts))
 


### PR DESCRIPTION
Hi,

I was working on a cluster machine with SLURM and I encountered the same error as below.
https://github.com/soravux/scoop/issues/26

If a node list assigned by SLURM contains nonconsecutive ones, error occurs at parseSLURM() in scoop/utils.py because 'bmin,bmax = rng.split('-')' does not work. For example, when a node list is 'host[001,003-004,006]', '001' and '006' cannot be parsed. Thus I simply fixed this.

Best regards,