### PR TITLE
allow hosts with only AAAA (IPV6) addresses to be used

### DIFF
--- a/scoop/broker/__main__.py
+++ b/scoop/broker/__main__.py
@@ -101,8 +101,8 @@ if __name__ == "__main__":
         import os
         import sys
         sys.stdout.write("{0},{1}\n".format(
-            thisBroker.tSockPort,
-            thisBroker.infoSockPort,
+            thisBroker.t_sock_port,
+            thisBroker.info_sock_port,
         ))
         sys.stdout.flush()
 

--- a/scoop/broker/brokerzmq.py
+++ b/scoop/broker/brokerzmq.py
@@ -75,6 +75,7 @@ class Broker(object):
 
         # zmq Socket for the tasks, replies and request.
         self.task_socket = self.context.socket(zmq.ROUTER)
+        self.task_socket.setsockopt(zmq.IPV4ONLY, 0)
         self.task_socket.setsockopt(zmq.ROUTER_MANDATORY, 1)
         self.task_socket.setsockopt(zmq.LINGER, 1000)
         self.t_sock_port = 0
@@ -99,6 +100,7 @@ class Broker(object):
 
         # zmq Socket for the pool informations
         self.info_socket = self.context.socket(zmq.PUB)
+        self.info_socket.setsockopt(zmq.IPV4ONLY, 0)
         self.info_socket.setsockopt(zmq.LINGER, 1000)
         self.info_sock_port = 0
         if mSock[-2:] == ":*":
@@ -114,6 +116,7 @@ class Broker(object):
 
         # Init connection to fellow brokers
         self.cluster_socket = self.context.socket(zmq.DEALER)
+        self.cluster_socket.setsockopt(zmq.IPV4ONLY, 0)
         self.cluster_socket.setsockopt_string(zmq.IDENTITY, self.getName())
             
         self.cluster_socket.setsockopt(zmq.RCVHWM, 0)


### PR DESCRIPTION
scoop/broker/__main__.py
This appears to be a typo.

scoop/_comm/scoopzmq.py
Tweak to allow IPv6-only hosts (remove hard-coded AF_INET)
Also, python-zmq doesn't appear to support tcp://[::]:1234 format with raw addresses, so set the "external_addr" to the hostname, which does work

scoop/_comm/scoopzmq.py and scoop/broker/brokerzmq.py
Disable zmq.IPV4ONLY, which is oddly enabled by default on newly-created ZMQ sockets.
