### PR TITLE
Fixing ssh host name problem.

### DIFF
--- a/scoop/_comm/scoopzmq.py
+++ b/scoop/_comm/scoopzmq.py
@@ -67,14 +67,18 @@ class ZMQCommunicator(object):
 
 
         # Get the current address of the interface facing the broker
-        info = socket.getaddrinfo(scoop.BROKER.externalHostname, scoop.BROKER.task_port)[0]
+        if scoop.BROKER.hostname == scoop.BROKER.externalHostname:
+            hostname = "127.0.0.1"
+        else:
+            hostname = scoop.BROKER.externalHostname
+        info = socket.getaddrinfo(hostname, scoop.BROKER.task_port)[0]
         s = socket.socket(info[0], socket.SOCK_DGRAM)
         s.connect(info[4][:2])
         external_addr = s.getsockname()[0]
         s.close()
 
         if external_addr in utils.loopbackReferences or info[0] == socket.AF_INET6:
-            external_addr = scoop.BROKER.externalHostname
+            external_addr = hostname
 
         # Create an inter-worker socket
         self.direct_socket_peers = []
@@ -206,13 +210,17 @@ class ZMQCommunicator(object):
             self.direct_socket.connect(new_peer)
 
     def _addBroker(self, brokerEntry):
+        if brokerEntry.hostname == brokerEntry.externalHostname:
+            hostname = "127.0.0.1"
+        else:
+            hostname = brokerEntry.externalHostname
         # Add a broker to the socket and the infosocket.
         broker_address = "tcp://{hostname}:{port}".format(
-            hostname=brokerEntry.hostname,
+            hostname=hostname,
             port=brokerEntry.task_port,
         )
         meta_address = "tcp://{hostname}:{port}".format(
-            hostname=brokerEntry.hostname,
+            hostname=hostname,
             port=brokerEntry.info_port,
         )
         self.socket.connect(broker_address)

--- a/scoop/launch/workerLaunch.py
+++ b/scoop/launch/workerLaunch.py
@@ -120,11 +120,7 @@ class Host(object):
         worker = self.workersArguments
         c = []
 
-        # If broker is on localhost
-        if self.hostname == worker.brokerHostname:
-            broker = "127.0.0.1"
-        else:
-            broker = worker.brokerHostname
+        broker = worker.brokerHostname
 
         if worker.nice is not None:
             c.extend(['--nice', str(worker.nice)])

--- a/scoop/launcher.py
+++ b/scoop/launcher.py
@@ -242,7 +242,6 @@ class ScoopApp(object):
 
     def run(self):
         """Launch the broker(s) and worker(s) assigned on every hosts."""
-        # Launch the broker(s)
         for hostname, nb_brokers in self.broker_hosts:
             for ind in range(nb_brokers):
                 if self.externalHostname in utils.localHostnames:

--- a/scoop/launcher.py
+++ b/scoop/launcher.py
@@ -467,6 +467,7 @@ def main():
 
     if not args.external_hostname:
         args.external_hostname = [utils.externalHostname(hosts)]
+    utils.localHostnames.append(args.external_hostname[0])
 
     # Launch SCOOP
     thisScoopApp = ScoopApp(hosts, n, args.b,


### PR DESCRIPTION
Without this fix, the ssh host name must be the same as the PC name.

The fix will enable to use any host name.