### PR TITLE
MULTIPLE CHANGES to BUGFIX Dropped Futures

### DIFF
--- a/scoop/_comm/scoopzmq.py
+++ b/scoop/_comm/scoopzmq.py
@@ -392,11 +392,10 @@ class ZMQCommunicator(object):
 
         self._sendReply(
             future.id[0],
-            pickle.dumps(future.id, pickle.HIGHEST_PROTOCOL),
             pickle.dumps(future, pickle.HIGHEST_PROTOCOL),
         )
 
-    def _sendReply(self, destination, fid, *args):
+    def _sendReply(self, destination, *args):
         """Send a REPLY directly to its destination. If it doesn't work, launch
         it back to the broker."""
         # Try to send the result directly to its parent
@@ -420,9 +419,10 @@ class ZMQCommunicator(object):
                 destination,
             ])
 
+    def sendDoneStatus(self, future):
         self.socket.send_multipart([
             STATUS_DONE,
-            fid,
+            pickle.dumps(future.id)
         ])
 
     def sendStatusRequest(self, future):

--- a/scoop/broker/brokerzmq.py
+++ b/scoop/broker/brokerzmq.py
@@ -258,6 +258,7 @@ class Broker(object):
                 address = msg[0]
                 try:
                     tasks_ids = pickle.loads(msg[2])
+                    tasks_ids = set(pickle.dumps(x, pickle.HIGHEST_PROTOCOL) for x in tasks_ids)
                 except:
                     self.logger.error("Could not unpickle status update message.")
                 else:

--- a/scoop/futures.py
+++ b/scoop/futures.py
@@ -301,7 +301,7 @@ def submit(func, *args, **kwargs):
     child = _createFuture(func, *args, **kwargs)
 
     control.futureDict[control.current.id].children[child] = None
-    control.execQueue.append(child)
+    control.execQueue.append_movable(child)
     return child
 
 
@@ -322,7 +322,6 @@ def _waitAny(*children):
         if future.exceptionValue:
             raise future.exceptionValue
         if future._ended():
-            future._delete()
             yield future
             n -= 1
         else:
@@ -337,7 +336,6 @@ def _waitAny(*children):
             raise childFuture.exceptionValue
         # Only yield if executed future was in children, otherwise loop
         if childFuture in children:
-            childFuture._delete()
             yield childFuture
             n -= 1
 


### PR DESCRIPTION
This is a surgical change in SCOOP that fixes many of its previous issues and finally makes it useful along with the communication error robustness.

I have slightly changed the run control loop, sendResult, made the deletes and appends more explicit, and fixed #65 fixed #66 (which was already fixed by #63) and fixed #64.

All tests seem to be passing except the SLURM tests.

Also added some documentation to the code.