### PR TITLE
Add sys.exit call at end of scoop/bootstrap/__main__.py

### DIFF
--- a/scoop/bootstrap/__main__.py
+++ b/scoop/bootstrap/__main__.py
@@ -296,3 +296,4 @@ class Bootstrap(object):
 if __name__ == "__main__":
     b = Bootstrap()
     b.main()
+    sys.exit(os.EX_OK)


### PR DESCRIPTION
If a Popen.terminate() is called without setting an exit code a resource warning is displayed. Reproducible on Python >3.6

```
subprocess.py:766: ResourceWarning: subprocess <PID> is still running
  ResourceWarning, source=self)
```