### PR TITLE
Wait for terminated process to create exit status

### DIFF
--- a/scoop/launch/workerLaunch.py
+++ b/scoop/launch/workerLaunch.py
@@ -222,5 +222,6 @@ class Host(object):
         for process in self.subprocesses:
             try:
                 process.terminate()
+                process.wait()
             except OSError:
                 pass


### PR DESCRIPTION
resourceWarning is produced if __del__ is called on worker process before process has terminated and registered process.returncode [Python>3.6]