### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/object.py
+++ b/examples/object.py
@@ -35,7 +35,7 @@ def modifyClass(myInstance):
 def main():
     # Create object instances
     myInstances = [myClass() for _ in range(20)]
-    # Modify them parallely
+    # Modify them parallelly
     myAnswers = list(futures.map(modifyClass, myInstances))
 
     # Each result is a new object with the modifications applied

--- a/examples/rssDoc.py
+++ b/examples/rssDoc.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
                     len(leftSignal),
                     PARALLEL_SIZE,
                     )
-    # Execute the RSS computation parallely
+    # Execute the RSS computation parallelly
     presult = futures.mapReduce(RSS,
                                 operator.add,
                                 indexes,

--- a/examples/tree/Tree.py
+++ b/examples/tree/Tree.py
@@ -103,7 +103,7 @@ def executeTree(address=[]):
     """This function executes a tree. To limit the size of the arguments passed
     to the function, the tree must be loaded in memory in every worker. To do
     this, simply call "Tree = importTree(filename)" before using the startup
-    method of the parralisation library you are using"""
+    method of the parallelisation library you are using"""
     global nodeDone
     # Get tree subsection
     localTree = getTree(address)

--- a/examples/tree_traversal.py
+++ b/examples/tree_traversal.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
 
     print("Tree generation done.")
 
-    # Splits the tree in two and process the left and right branches parallely
+    # Splits the tree in two and process the left and right branches parallelly
     ts = time.time()
     presult = max(
         futures.map(

--- a/scoop/_control.py
+++ b/scoop/_control.py
@@ -89,7 +89,7 @@ class _stat(deque):
 
 
 def advertiseBrokerWorkerDown(exctype, value, traceback):
-    """Hook advertizing the broker if an impromptu shutdown is occuring."""
+    """Hook advertising the broker if an impromptu shutdown is occuring."""
     if not scoop.SHUTDOWN_REQUESTED:
         execQueue.shutdown()
     sys.__excepthook__(exctype, value, traceback)

--- a/scoop/launcher.py
+++ b/scoop/launcher.py
@@ -201,7 +201,7 @@ class ScoopApp(object):
             The returned args and kwargs must ordered/named according to the namedtuple
             in LAUNCH_HOST_CLASS.LAUNCHING_ARGUMENTS .
 
-            both args and kwargs are supported for full flexibilty,
+            both args and kwargs are supported for full flexibility,
             but usage of kwargs only is strongly advised.
         """
         args = []

--- a/scoop/utils.py
+++ b/scoop/utils.py
@@ -130,7 +130,7 @@ def getCPUcount():
 
 
 def getEnv():
-    """Return the launching environnement"""
+    """Return the launching environment"""
     if "SLURM_NODELIST" in os.environ:
         return "SLURM"
     elif "PBS_ENVIRONMENT" in os.environ:


### PR DESCRIPTION
There are small typos in:
- examples/object.py
- examples/rssDoc.py
- examples/tree/Tree.py
- examples/tree_traversal.py
- scoop/_control.py
- scoop/launcher.py
- scoop/utils.py

Fixes:
- Should read `parallelly` rather than `parallely`.
- Should read `parallelisation` rather than `parralisation`.
- Should read `flexibility` rather than `flexibilty`.
- Should read `environment` rather than `environnement`.
- Should read `advertising` rather than `advertizing`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md